### PR TITLE
[FEAT] api 응답 통일, 에러 핸들러 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // security
     implementation 'io.jsonwebtoken:jjwt-api:0.12.3'

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/ApiResponse.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/ApiResponse.java
@@ -1,0 +1,39 @@
+package com.swunitzel.fiterview.apiPayload;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.swunitzel.fiterview.apiPayload.code.BaseCode;
+import com.swunitzel.fiterview.apiPayload.code.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})//json응답 필드 순서
+public class ApiResponse<T> {
+    @JsonProperty("isSuccess")
+    private final Boolean isSuccess;
+    private final String code;
+    private final String message;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T result;
+
+
+    // 성공한 경우 응답 생성
+
+    public static <T> ApiResponse<T> onSuccess(T result){
+        return new ApiResponse<>(true, SuccessStatus._OK.getCode() , SuccessStatus._OK.getMessage(), result);
+    }
+
+    public static <T> ApiResponse<T> of(BaseCode code, T result){
+        return new ApiResponse<>(true, code.getReasonHttpStatus().getCode() , code.getReasonHttpStatus().getMessage(), result);
+    }
+
+
+    // 실패한 경우 응답 생성
+    public static <T> ApiResponse<T> onFailure(String code, String message, T data){
+        return new ApiResponse<>(false, code, message, data);
+    }
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/code/BaseCode.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/code/BaseCode.java
@@ -1,0 +1,7 @@
+package com.swunitzel.fiterview.apiPayload.code;
+
+public interface BaseCode {
+    public ReasonDTO getReason();
+
+    public ReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/code/BaseErrorCode.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.swunitzel.fiterview.apiPayload.code;
+
+public interface BaseErrorCode {
+
+    public ErrorReasonDTO getReason();
+
+    public ErrorReasonDTO getReasonHttpStatus();
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/code/ErrorReasonDTO.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/code/ErrorReasonDTO.java
@@ -1,0 +1,16 @@
+package com.swunitzel.fiterview.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ErrorReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+    public boolean getIsSuccess(){return isSuccess;};
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/code/ReasonDTO.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/code/ReasonDTO.java
@@ -1,0 +1,15 @@
+package com.swunitzel.fiterview.apiPayload.code;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Builder
+public class ReasonDTO {
+    private HttpStatus httpStatus;
+    private final boolean isSuccess;
+    private final String code;
+    private final String message;
+
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/code/status/ErrorStatus.java
@@ -1,0 +1,46 @@
+package com.swunitzel.fiterview.apiPayload.code.status;
+
+import com.swunitzel.fiterview.apiPayload.code.BaseErrorCode;
+import com.swunitzel.fiterview.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseErrorCode {
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+    _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON400","잘못된 요청입니다."),
+    _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
+    _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
+
+    // 생활기록부 오류
+    _SCHOOL_RECORD_NOT_FOUND(HttpStatus.BAD_REQUEST, "SCHOOL-RECORD403", "사용자의 생활기록부 분석 정보가 존재하지 않습니다"),
+
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ErrorReasonDTO getReason() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .build();
+    }
+
+    @Override
+    public ErrorReasonDTO getReasonHttpStatus() {
+        return ErrorReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(false)
+                .httpStatus(httpStatus)
+                .build();
+    }
+
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/code/status/SuccessStatus.java
@@ -1,0 +1,42 @@
+package com.swunitzel.fiterview.apiPayload.code.status;
+
+
+import com.swunitzel.fiterview.apiPayload.code.BaseCode;
+import com.swunitzel.fiterview.apiPayload.code.ReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus implements BaseCode {
+    // 일반적인 응답
+    _OK(HttpStatus.OK, "COMMON200", "성공입니다.");
+
+    // 멤버 관련 응답
+
+    // ~~~ 관련 응답
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ReasonDTO getReason() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .build();
+    }
+
+    @Override
+    public ReasonDTO getReasonHttpStatus() {
+        return ReasonDTO.builder()
+                .message(message)
+                .code(code)
+                .isSuccess(true)
+                .httpStatus(httpStatus)
+                .build();
+    }
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/exception/ExceptionAdvice.java
@@ -1,0 +1,91 @@
+package com.swunitzel.fiterview.apiPayload.exception;
+
+import com.swunitzel.fiterview.apiPayload.ApiResponse;
+import com.swunitzel.fiterview.apiPayload.code.ErrorReasonDTO;
+import com.swunitzel.fiterview.apiPayload.code.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.ConstraintViolationException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class}) // 패키지 지정
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<Object> validation(ConstraintViolationException e, WebRequest request) {
+        String errorMessage = e.getConstraintViolations().stream()
+                .map(constraintViolation -> constraintViolation.getMessage())
+                .findFirst()
+                .orElse("ConstraintViolationException 발생");
+
+        return handleExceptionInternalConstraint(e, ErrorStatus.valueOf(errorMessage), HttpHeaders.EMPTY, request);
+    }
+
+    @Override
+    public ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+
+        Map<String, String> errors = new LinkedHashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(fieldError -> {
+            String fieldName = fieldError.getField();
+            String errorMessage = Optional.ofNullable(fieldError.getDefaultMessage()).orElse("");
+            errors.merge(fieldName, errorMessage, (existing, newMsg) -> existing + ", " + newMsg);
+        });
+
+        return handleExceptionInternalArgs(e, HttpHeaders.EMPTY, ErrorStatus.valueOf("_BAD_REQUEST"), request, errors);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> exception(Exception e, WebRequest request) {
+        log.error("Unhandled exception occurred", e);
+        return handleExceptionInternalFalse(e, ErrorStatus._INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY,
+                ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus(), request, e.getMessage());
+    }
+
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<Object> onThrowException(GeneralException generalException, HttpServletRequest request) {
+        ErrorReasonDTO errorReasonHttpStatus = generalException.getErrorReasonHttpStatus();
+        return handleExceptionInternal(generalException, errorReasonHttpStatus, null, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternal(Exception e, ErrorReasonDTO reason,
+                                                           HttpHeaders headers, HttpServletRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(reason.getCode(), reason.getMessage(), null);
+        WebRequest webRequest = new ServletWebRequest(request);
+        return super.handleExceptionInternal(e, body, headers, reason.getHttpStatus(), webRequest);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalFalse(Exception e, ErrorStatus errorStatus,
+                                                                HttpHeaders headers, HttpStatus status,
+                                                                WebRequest request, String errorPoint) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), errorPoint);
+        return super.handleExceptionInternal(e, body, headers, status, request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalArgs(Exception e, HttpHeaders headers, ErrorStatus errorStatus,
+                                                               WebRequest request, Map<String, String> errorArgs) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), errorArgs);
+        return super.handleExceptionInternal(e, body, headers, errorStatus.getHttpStatus(), request);
+    }
+
+    private ResponseEntity<Object> handleExceptionInternalConstraint(Exception e, ErrorStatus errorStatus,
+                                                                     HttpHeaders headers, WebRequest request) {
+        ApiResponse<Object> body = ApiResponse.onFailure(errorStatus.getCode(), errorStatus.getMessage(), null);
+        return super.handleExceptionInternal(e, body, headers, errorStatus.getHttpStatus(), request);
+    }
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/exception/GeneralException.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/exception/GeneralException.java
@@ -1,0 +1,20 @@
+package com.swunitzel.fiterview.apiPayload.exception;
+
+import com.swunitzel.fiterview.apiPayload.code.BaseErrorCode;
+import com.swunitzel.fiterview.apiPayload.code.ErrorReasonDTO;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GeneralException extends RuntimeException {
+    private BaseErrorCode code;
+
+    public ErrorReasonDTO getErrorReason() {
+        return this.code.getReason();
+    }
+
+    public ErrorReasonDTO getErrorReasonHttpStatus(){
+        return this.code.getReasonHttpStatus();
+    }
+}

--- a/src/main/java/com/swunitzel/fiterview/apiPayload/exception/handler/SchoolRecordHandler.java
+++ b/src/main/java/com/swunitzel/fiterview/apiPayload/exception/handler/SchoolRecordHandler.java
@@ -1,0 +1,10 @@
+package com.swunitzel.fiterview.apiPayload.exception.handler;
+
+import com.swunitzel.fiterview.apiPayload.code.BaseErrorCode;
+import com.swunitzel.fiterview.apiPayload.exception.GeneralException;
+
+public class SchoolRecordHandler extends GeneralException {
+    public SchoolRecordHandler(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/swunitzel/fiterview/controller/SchoolRecordController.java
+++ b/src/main/java/com/swunitzel/fiterview/controller/SchoolRecordController.java
@@ -1,0 +1,25 @@
+package com.swunitzel.fiterview.controller;
+
+import com.swunitzel.fiterview.apiPayload.ApiResponse;
+import com.swunitzel.fiterview.dto.SchoolRecordResponseDto;
+import com.swunitzel.fiterview.jwt.CustomUserDetails;
+import com.swunitzel.fiterview.services.SchoolRecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/school-records")
+public class SchoolRecordController {
+
+    private final SchoolRecordService schoolRecordService;
+
+    @GetMapping("/analyze")
+    public ApiResponse<SchoolRecordResponseDto.SchoolRecordDto> getSchoolRecord(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        SchoolRecordResponseDto.SchoolRecordDto schoolRecordDto = schoolRecordService.getSchoolRecord(userDetails.getUsername());
+        return ApiResponse.onSuccess(schoolRecordDto);
+    }
+}


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- api 응답 통일을 위해 코드 추가
- 아래 순서에 맞춰 응답 생성 
<img width="493" alt="스크린샷 2025-06-03 오후 9 41 23" src="https://github.com/user-attachments/assets/67f60d4b-66e6-4594-b319-fbe5c8b69fa1" />


## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #21 


